### PR TITLE
Add support to pnp4nagios graphing.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 icinga2_modules:
   - command
-  - graphite
   - ido-mysql
+  - perfdata
 icinga2_repository: icinga-stretch
 icinga2_admin_username: icingaadmin
 icinga2_plugin_custom_dir: /opt/nagios/netplug/netplug_commands

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,15 @@
     - icinga2-ido-mysql
     - monitoring-plugins
 
+- name: Copy Icinga config files
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  loop:
+    - { src: ido-mysql.conf.j2, dest: /etc/icinga2/features-available/ido-mysql.conf }
+    - { src: perfdata.conf.j2, dest: /etc/icinga2/features-available/perfdata.conf }
+  notify: reload icinga
+
 - name: Enable Icinga modules
   icinga2_feature:
     name: "{{ item }}"
@@ -32,15 +41,6 @@
   when:
     - db_created.changed
     - synced_config is not defined
-
-- name: Copy Icinga config files
-  template:
-    src: "{{ item.key }}"
-    dest: "{{ item.value }}"
-  with_dict:
-    ido-mysql.conf.j2: /etc/icinga2/features-available/ido-mysql.conf
-    graphite.conf.j2: /etc/icinga2/features-available/graphite.conf
-  notify: reload icinga
 
 - name: Copy configuration files under /etc/icinga2/conf.d
   template:
@@ -69,3 +69,23 @@
     state: absent
   with_items: "{{ icinga2_unwanted_files }}"
   notify: reload icinga
+
+- name: Copy nagios ssh private key
+  copy:
+    src: "{{ PLAYBOOK_PRIVATE_ROLE_ASSETS_PATH }}nagios_host/nagios"
+    dest: /var/lib/nagios/.ssh/id_rsa
+    owner: nagios
+    group: nagios
+    mode: u=rw,g=,o=
+  tags: icinga_ssh
+
+- name: Set ssh config
+  copy:
+    content: |
+      Host *
+        StrictHostKeyChecking no
+    dest: /var/lib/nagios/.ssh/config
+    owner: nagios
+    group: nagios
+    mode: u=rw,g=,o=
+  tags: icinga_ssh

--- a/templates/perfdata.conf.j2
+++ b/templates/perfdata.conf.j2
@@ -1,0 +1,5 @@
+
+object PerfdataWriter "perfdata" {
+    host_format_template = "DATATYPE::HOSTPERFDATA\tTIMET::$icinga.timet$\tHOSTNAME::$host.name$\tHOSTPERFDATA::$host.perfdata$\tHOSTCHECKCOMMAND::check_$host.check_command$\tHOSTSTATE::$host.state$\tHOSTSTATETYPE::$host.statetype$"
+    service_format_template = "DATATYPE::SERVICEPERFDATA\tTIMET::$icinga.timet$\tHOSTNAME::$host.name$\tSERVICEDESC::$service.name$\tSERVICEPERFDATA::$service.perfdata$\tSERVICECHECKCOMMAND::$pnp_check_name$\tHOSTSTATE::$host.state$\tHOSTSTATETYPE::$host.statetype$\tSERVICESTATE::$service.state$\tSERVICESTATETYPE::$service.statetype$"
+}

--- a/templates/services.conf.j2
+++ b/templates/services.conf.j2
@@ -1,6 +1,7 @@
 apply Service "ping4" {
   import "generic-service"
   check_command = "ping4"
+  vars.pnp_check_name = "check_ping"
   assign where host.address
 }
 

--- a/templates/templates.conf.j2
+++ b/templates/templates.conf.j2
@@ -7,12 +7,19 @@ template Host "generic-host" {
   }
 
   check_command = "hostalive"
+  vars.pnp_check_name = "check_host-alive"
 }
 
 template Service "generic-service" {
   max_check_attempts = 5
   check_interval = 1m
   retry_interval = 30s
+
+  // pnp4nagios doesn't correctly detect template because it expects
+  // check_command to begin with "check_". This is corrected here and
+  // in perfdata conf by adding pnp_check_name for overriding template.
+  // See: https://github.com/Icinga/icinga2/issues/1886
+  vars.pnp_check_name = "check_$service.check_command$"
 }
 
 template Notification "generic-notification" {
@@ -47,7 +54,12 @@ template Notification "mail-service-notification" {
 }
 
 template Service "ssh-service" {
-  import "generic-service"
+  max_check_attempts = 5
+  check_interval = 1m
+  retry_interval = 30s
+
+  // Set correct template for services called with ssh.
+  vars.pnp_check_name = "check_$check_command$"
 
   vars.check_command = check_command
   vars += get_check_command(check_command).vars


### PR DESCRIPTION
* Add nagios ssh key setup used for checking over ssh.
* Enable perfdata module and add config to it.
* Create option 'vars.pnp_check_name' for overriding pnp4nagios
  graphing template. This is needed as pnp4nagios expects
  check_command to start with "check_" and icinga2 doesn't.
  It also allows overriding template in ssh checks.