### PR TITLE
Removing site 'now.libraries.fi'

### DIFF
--- a/templates/http-services.conf.j2
+++ b/templates/http-services.conf.j2
@@ -184,14 +184,6 @@ apply Service "kiravoprojekti.kirjastot.fi HTTP" {
   assign where host.name == "smallsites.kirjastot.fi"
 }
 
-apply Service "now.libraries.fi HTTP" {
-  import "generic-service"
-  check_command = "http"
-  vars.http_uri = "/"
-  vars.http_vhost = "now.libraries.fi"
-  assign where host.name == "smallsites.kirjastot.fi"
-}
-
 apply Service "sustainability.libraries.fi HTTP" {
   import "generic-service"
   check_command = "http"


### PR DESCRIPTION
now.libraries.fi site is taken down. No need to have any reference's to it.